### PR TITLE
adds bucket counters, fixes missing chef include

### DIFF
--- a/application/controllers/api.php
+++ b/application/controllers/api.php
@@ -18,6 +18,16 @@ class API extends MY_Controller {
 		}
 	}
 
+	public function counters() {
+
+		try {
+			$counters = $this->bucket_model->counters();
+			$this->OKResponse("counters",$counters);
+		} catch(Exception $e) {
+			$this->ErrorResponse("counters",array("exception"=>$e->getMessage()));
+		}
+	}
+
 	public function events($bucket,$limit=10) {
 
 		try {

--- a/application/models/bucket_model.php
+++ b/application/models/bucket_model.php
@@ -17,6 +17,10 @@ class Bucket_model extends CI_Model {
 				},$keys);
 	}
 
+	public function counters() {
+		return $this->redis->zrevrangebyscore("EventsD:bucket_scores:sorted_set","+inf","-inf",array("withscores"=>true));
+	}
+
 	public function events($bucket,$limit) {
 		$events = $this->redis->zrevrange(self::keyName($bucket),0,($limit - 1));
 		return array_map(function($s) {

--- a/eventsd/datastore.js
+++ b/eventsd/datastore.js
@@ -7,6 +7,7 @@
 redis_handle = null;
 
 max_bucket_events = 10;
+bucket_scores_set = "EventsD:bucket_scores:sorted_set";
 
 /**
  * sets redis handle
@@ -41,5 +42,8 @@ exports.insert = function(ob_event) {
 		.exec(function(err,replies) {
 			if(err) throw err;
 		});
+
+	// bucket total events counters
+	redis_handle.zincrby(bucket_scores_set,1,bucket);
 
 }

--- a/vagrant/cookbooks/eventsd_dashboard/recipes/setup_supervisord.rb
+++ b/vagrant/cookbooks/eventsd_dashboard/recipes/setup_supervisord.rb
@@ -1,4 +1,5 @@
 
+include_recipe "eventsd_dashboard::default"
 
 {
 	"python-meld3" => "python-meld3-0.6.10-1.noarch.rpm",


### PR DESCRIPTION
- need to see the most active buckets that are potentially overloading eventsd server
- adds counters that are incremented whenever a bucket receives an event
- deploy broke last time, so add a missing include that will insure that the attachments directory exists
