### PR TITLE
constructs a proper favoriteBuckets array if HTML storage is missing key

### DIFF
--- a/browser/assets/js/angular/controllers.js
+++ b/browser/assets/js/angular/controllers.js
@@ -48,6 +48,9 @@ appControllers.controller('bucketsCtrl', ['$scope', '$http', '$modal', '$log', '
 			bucketsApi = {
 			favoriteHandler: function(bucket) {
 				var favoriteBuckets = localStorageService.get('favoriteBuckets');
+				if (!_.isArray(favoriteBuckets)) {
+					favoriteBuckets = [];
+				}
 
 				if (!_.isUndefined(bucket)) {
 					var index = _.indexOf(favoriteBuckets, bucket);


### PR DESCRIPTION
fixed issue where the html favorites storage was not initializing
