### PR TITLE
fixed event browser mouseover actions

### DIFF
--- a/browser/assets/js/angular/controllers.js
+++ b/browser/assets/js/angular/controllers.js
@@ -199,8 +199,10 @@ appControllers.controller('bucketsCtrl', ['$scope', '$http', '$modal', '$log', '
 	}
 ]);
 
-appControllers.controller('eventsCtrl', ['$scope', '$http', '$routeParams', 'eventService',
-	function ($scope, $http, $routeParams, eventService) {
+appControllers.controller('eventsCtrl', ['$scope', '$http', '$routeParams', '$timeout', 'eventService',
+	function ($scope, $http, $routeParams, $timeout, eventService) {
+		var rowTimeout;
+
 		$scope.snippy = true;
 		$scope.breadCrumb = '<a href="#/">Home</a> > Event Browser';
 		eventService.getEventsEndpoint($routeParams.bucketId).
@@ -228,6 +230,16 @@ appControllers.controller('eventsCtrl', ['$scope', '$http', '$routeParams', 'eve
 		$scope.setPage = function (pageNum) {
 			$scope.currentPage = pageNum;
 			$scope.pageChanged();
+		};
+
+		$scope.checkIn = function(code, time) {
+			rowTimeout = $timeout(function () {
+				$scope.loadSnip(code, time);
+			}, 500);
+		};
+
+		$scope.checkOut = function() {
+			$timeout.cancel(rowTimeout);
 		};
 
 		$scope.loadSnip = function(code, time) {

--- a/browser/views/events.html
+++ b/browser/views/events.html
@@ -11,9 +11,10 @@
 			</tr>
 			</thead>
 			<tbody>
-			<tr ng-repeat="row in table_data_paginated | orderBy:predicate:reverse">
-				<td ng-click="loadSnip(row.data, row.time);">
-					<a href="">{{row.name}}</a>
+			<tr ng-repeat="row in table_data_paginated | orderBy:predicate:reverse"
+				ng-mouseenter="checkIn(row.data, row.time)" ng-mouseleave="checkOut()">
+				<td>
+					<a ng-click="loadSnip(row.data, row.time)" href="">{{row.name}}</a>
 				</td>
 				<td>{{row.size}}</td>
 				<td>{{row.time | date:'medium'}}</td>


### PR DESCRIPTION
mousing over an event in the events view will defer a load, as long as you stay hovered over that row for a half second, the data preview will load below.
