### PR TITLE
add support for http basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vagrant/cache/*
 *.swp
 .*.swp
 node_modules
+.htaccess
+.htpasswd

--- a/vagrant/cookbooks/eventsd_dashboard/attributes/default.rb
+++ b/vagrant/cookbooks/eventsd_dashboard/attributes/default.rb
@@ -24,3 +24,7 @@ default[:eventsd_dashboard][:php_conf] = [
 # attachments
 default[:eventsd_dashboard][:tmp_dir] = "/tmp/attachments"
 default[:eventsd_dashboard][:attachment_url] = "http://raven-opensource.s3.amazonaws.com"
+
+# http auth
+default[:eventsd_dashboard][:admin][:username] = ""
+default[:eventsd_dashboard][:admin][:password] = ""

--- a/vagrant/cookbooks/eventsd_dashboard/metadata.json
+++ b/vagrant/cookbooks/eventsd_dashboard/metadata.json
@@ -175,6 +175,36 @@
 
       ],
       "calculated": false
+    },
+    "eventsd_dashboard/admin/username": {
+      "display_name": "Admin Username",
+      "description": "Admin Username",
+      "required": "optional",
+      "type": "string",
+      "recipes": [
+        "eventsd_dashboard::default",
+        "eventsd_dashboard::deploy_tag",
+        "eventsd_dashboard::setup_htauth"
+      ],
+      "choice": [
+
+      ],
+      "calculated": false
+    },
+    "eventsd_dashboard/admin/password": {
+      "display_name": "Admin Password",
+      "description": "Admin Password",
+      "required": "optional",
+      "type": "string",
+      "recipes": [
+        "eventsd_dashboard::default",
+        "eventsd_dashboard::deploy_tag",
+        "eventsd_dashboard::setup_htauth"
+      ],
+      "choice": [
+
+      ],
+      "calculated": false
     }
   },
   "groupings": {

--- a/vagrant/cookbooks/eventsd_dashboard/metadata.rb
+++ b/vagrant/cookbooks/eventsd_dashboard/metadata.rb
@@ -91,3 +91,17 @@ attribute "eventsd_dashboard/deploy/key",
     :required => "optional",
     :type => "string",
     :recipes => ["eventsd_dashboard::default","eventsd_dashboard::deploy_tag"]
+
+attribute "eventsd_dashboard/admin/username",
+    :display_name => "Admin Username",
+    :description => "Admin Username",
+    :required => "optional",
+    :type => "string",
+    :recipes => ["eventsd_dashboard::default","eventsd_dashboard::deploy_tag","eventsd_dashboard::setup_htauth"]
+
+attribute "eventsd_dashboard/admin/password",
+    :display_name => "Admin Password",
+    :description => "Admin Password",
+    :required => "optional",
+    :type => "string",
+    :recipes => ["eventsd_dashboard::default","eventsd_dashboard::deploy_tag","eventsd_dashboard::setup_htauth"]

--- a/vagrant/cookbooks/eventsd_dashboard/recipes/deploy_tag.rb
+++ b/vagrant/cookbooks/eventsd_dashboard/recipes/deploy_tag.rb
@@ -27,3 +27,4 @@ git node[:eventsd_dashboard][:vhost][:documentroot] do
 end
 
 include_recipe "eventsd_dashboard::setup_supervisord"
+include_recipe "eventsd_dashboard::setup_htauth"

--- a/vagrant/cookbooks/eventsd_dashboard/recipes/setup_htauth.rb
+++ b/vagrant/cookbooks/eventsd_dashboard/recipes/setup_htauth.rb
@@ -1,0 +1,23 @@
+
+passwd_file = "#{node[:eventsd_dashboard][:vhost][:documentroot]}/.htpasswd"
+hashed_password = Digest::SHA1.base64digest node[:eventsd_dashboard][:admin][:password]
+file passwd_file do
+	content <<-EOH
+#{node[:eventsd_dashboard][:admin][:username]}:{SHA}#{hashed_password}
+	EOH
+end
+
+file "#{node[:eventsd_dashboard][:vhost][:documentroot]}/.htaccess" do
+	content <<-EOH
+AuthType basic
+AuthName "EventsD Browser'
+AuthUserFile #{passwd_file}
+Require valid-user
+
+# block .htaccess and .htpasswd if default apache confi didn't
+<Files ~ "^\.ht.*$">
+	Order allow,deny
+	Deny from all
+</Files>
+	EOH
+end

--- a/vagrant/roles/eventsd_dashboard.json
+++ b/vagrant/roles/eventsd_dashboard.json
@@ -19,7 +19,12 @@
 					"servername":"eventsd_dashboard.site",
 					"serveraliases":["www.eventsd_dashboard.site"],
 					"documentroot":"/home/webapps/eventsd_dashboard/"
+			},
+			"admin":{
+				"username":"admin",
+				"password":"password"
 			}
+
 		}
 	},
 	"override_attributes": {


### PR DESCRIPTION
- adds username and password input variables
- adds setup_htauth recipe which creates an .htpassword and .htaccess file using the above credentials
- by default does not create files in vagrant
- will create files when running deploy_tag (though probably not necessary since we're not doing cap-style deploy)
