### PR TITLE
removed controller declarations from html templates

### DIFF
--- a/application/public/views/buckets.html
+++ b/application/public/views/buckets.html
@@ -1,4 +1,4 @@
-<div ng-controller="bucketsCtrl">
+<div>
 	<summary></summary>
 	<header></header>
 	<div class="col-lg-8 content-margin">

--- a/application/public/views/events.html
+++ b/application/public/views/events.html
@@ -1,4 +1,4 @@
-<div ng-controller="eventsCtrl">
+<div>
 	<summary></summary>
 	<header></header>
 	<div class="col-lg-8 content-margin">


### PR DESCRIPTION
The controllers were being called twice. This was causing the init() methods in each of those controllers to fire twice, as a result, triggering the api routes twice. I discovered that you should be declaring your controllers in either the html templates or the router, not both. The router method seems cleaner.

http://stackoverflow.com/questions/15535336/combating-angularjs-executing-controller-twice
