### PR TITLE
Fix pubsub service name collision

### DIFF
--- a/vagrant/cookbooks/eventsd_dashboard/recipes/setup_eventsd.rb
+++ b/vagrant/cookbooks/eventsd_dashboard/recipes/setup_eventsd.rb
@@ -15,10 +15,10 @@ template "/etc/supervisor.d/eventsd.conf" do
     notifies :restart, "service[supervisord]", :delayed
 end
 
-template "/etc/supervisor.d/pubsub.conf" do
+template "/etc/supervisor.d/eventsd_pubsub.conf" do
     source "supervisor_program.conf.erb"
     variables ({
-            :name => "pubsub",
+            :name => "eventsd_pubsub",
             :command => "node pubsub.js",
             :directory => eventsd_dir,
             :numprocs => 1,


### PR DESCRIPTION
When using this recipe within vagrant, it collides with the RavenApp pubsub daemon, causing it to stop functioning.  This renames the eventsd pubsub daemon to be unique and all both of them to peacefully cohabitate.