### PR TITLE
NodeJS: conditional install

### DIFF
--- a/vagrant/cookbooks/eventsd_dashboard/attributes/default.rb
+++ b/vagrant/cookbooks/eventsd_dashboard/attributes/default.rb
@@ -32,3 +32,6 @@ default[:eventsd_dashboard][:application][:client_id] = ""
 default[:eventsd_dashboard][:application][:client_secret] = ""
 default[:eventsd_dashboard][:application][:client_redirect] = ""
 default[:eventsd_dashboard][:application][:db_file] = "database.sqlite"
+
+# install nodejs and npm? disable this if node is provided by another cookbook
+default[:eventsd_dashboard][:install_nodejs] = true

--- a/vagrant/cookbooks/eventsd_dashboard/recipes/default.rb
+++ b/vagrant/cookbooks/eventsd_dashboard/recipes/default.rb
@@ -7,8 +7,10 @@ end
 
 include_recipe "yum-epel"
 
-package "nodejs"
-package "npm"
+if node[:eventsd_dashboard][:install_nodejs] == true 
+	package "nodejs"
+	package "npm"
+end
 
 # configures epel and epel-rightscale repos
 include_recipe "eventsd_dashboard::setup_epel"


### PR DESCRIPTION
When included in raven vagrant, the nodejs install here conflicts.  This makes it optional so we can disable installation when nodejs is provided by something else.
